### PR TITLE
Focus on page load

### DIFF
--- a/web/src/app/activate/page.tsx
+++ b/web/src/app/activate/page.tsx
@@ -166,7 +166,7 @@ const RegisterPage = () => {
                 name="firstname"
                 label="Prénom"
                 neighborName="name"
-                render={(field) => <Input {...field} />}
+                render={(field) => <Input autoFocus {...field} />}
               />
               <CustomFormField
                 form={form}

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -56,6 +56,7 @@ const Login = () => {
               label="Email"
               render={(field) => (
                 <Input
+                  autoFocus
                   placeholder="prenom.nom@etu.ec-lyon.fr"
                   required
                   {...field}

--- a/web/src/app/recover/page.tsx
+++ b/web/src/app/recover/page.tsx
@@ -72,7 +72,11 @@ const RecoverPage = () => {
               name="email"
               label="Email"
               render={(field) => (
-                <Input placeholder="prenom.nom@etu.ec-lyon.fr" {...field} />
+                <Input
+                  autoFocus
+                  placeholder="prenom.nom@etu.ec-lyon.fr"
+                  {...field}
+                />
               )}
             />
             <LoadingButton

--- a/web/src/app/register/page.tsx
+++ b/web/src/app/register/page.tsx
@@ -90,7 +90,11 @@ const RegisterContent = () => {
               name="email"
               label="Email"
               render={(field) => (
-                <Input placeholder="prenom.nom@etu.ec-lyon.fr" {...field} />
+                <Input
+                  autoFocus
+                  placeholder="prenom.nom@etu.ec-lyon.fr"
+                  {...field}
+                />
               )}
             />
             <LoadingButton

--- a/web/src/app/reset-password/page.tsx
+++ b/web/src/app/reset-password/page.tsx
@@ -78,7 +78,7 @@ const ResetPasswordPage = () => {
               name="password"
               label="Mot de passe"
               render={(field) => {
-                return <PasswordInputWithStrength {...field} />;
+                return <PasswordInputWithStrength autoFocus {...field} />;
               }}
             />
             <LoadingButton


### PR DESCRIPTION
Minor improvement: when landing on a page, gives focus to the 1st text input.
> [!NOTE]
> Mobile browsers explicitly disallow showing the virtual keyboard on page load, so we can't really do much more